### PR TITLE
fix initialization of tables TEAM and TEAM_PERSON

### DIFF
--- a/src/test/java/no/kodemaker/ps/jdbiapp/repository/TeamDaoTest.java
+++ b/src/test/java/no/kodemaker/ps/jdbiapp/repository/TeamDaoTest.java
@@ -22,8 +22,8 @@ public class TeamDaoTest {
         new AddressTableCreator().resetTable();
         new PersonTableCreator().resetTable();
         new PersonAddressTableCreator().resetTable();
-        new TeamDaoJdbi.TeamPersonTableCreator().resetTable();
         new TeamDaoJdbi.TeamTableCreator().resetTable();
+        new TeamDaoJdbi.TeamPersonTableCreator().resetTable();
 
         personDao = new PersonJdbiDao3();
         DbSeeder.initPersonTable(personDao);


### PR DESCRIPTION
TeamDaoTest test class fails due to incorrect order of create statements for TEAM and TEAM_PERSON tables. As a solution I've put create statement for TEAM before the create statement for TEAM_PERSON.
